### PR TITLE
Relax base dependency to make project buildable without allow-newer

### DIFF
--- a/gram.cabal
+++ b/gram.cabal
@@ -19,14 +19,14 @@ library
   -- exposed-modules:    
   -- other-modules:      
   -- other-extensions:
-  build-depends:       base >=4.11
+  build-depends:       base >=4.9
   hs-source-dirs:      src
   default-language:    Haskell2010
 
 executable gram
   main-is:             Main.hs
   -- other-extensions:
-  build-depends:       base >=4.11
+  build-depends:       base >=4.9
                      , curl
                      , telegram-api
                      , http-client


### PR DESCRIPTION
After this patch stack won't require `allow-newer: true` entry in global config (`~/.stack/config.yaml`)